### PR TITLE
Change default target type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "target_group_protocol" {
 }
 
 variable "target_type" {
-  default     = "instance"
+  default     = "ip"
   type        = "string"
   description = "The type of target that you must specify when registering targets with this target group. The possible values are instance or ip."
 }


### PR DESCRIPTION
When using ECS, you have to select ip. And since it is thought that ECS (or EKS) will become the default in the near future, we decided that it is preferable to set ip to the default value.

Based on https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html#load-balancing-concepts