### PR TITLE
Change default enable redirect HTTP to HTTPS

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "enable_http_listener" {
 }
 
 variable "enable_redirect_http_to_https" {
-  default     = false
+  default     = true
   type        = "string"
   description = "If true, the HTTP listener of HTTPS redirection will be created."
 }


### PR DESCRIPTION
The reason was that Chrome will mark all HTTP sites as 'not secure'

See https://security.googleblog.com/2018/02/a-secure-web-is-here-to-stay.html